### PR TITLE
Developers avatars (54x60) clip path

### DIFF
--- a/_includes/already-with-us.html
+++ b/_includes/already-with-us.html
@@ -35,7 +35,17 @@
         <div class="already-with-us__slider js-already-with-us-slider">
             {% for developer in data.developers %}
                 <div class="px-1 px-md-2 text-center">
-                    <img src="{{ developer.avatar_url | relative_url }}" width="54" height="60" alt="{{ developer.name }}" class="img-fluid mx-auto mb-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="54" height="60" viewBox="0 0 54 60" class="mx-auto mb-1">
+                        <defs>
+                            <path d="M26.76,0a7.17,7.17,0,0,0-3.41,1L3.41,12.58A6.62,6.62,0,0,0,0,18.39V41.61a6.72,6.72,0,0,0,3.41,5.81L23.35,59a7.4,7.4,0,0,0,3.41,1,7.9,7.9,0,0,0,3.89-1L50.59,47.42A6.76,6.76,0,0,0,54,41.61V18.39a6.66,6.66,0,0,0-3.41-5.81L30.65,1A7.7,7.7,0,0,0,26.76,0Z" id="path2"></path>
+                        </defs>
+                        <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <mask id="mask2" fill="white">
+                                <use xlink:href="#path2"></use>
+                            </mask>
+                            <image mask="url(#mask2)" width="54" height="60" xlink:href="{{ developer.avatar_url | relative_url }}"></image>
+                        </g>
+                    </svg>
                     <p class="small">
                         {{ developer.name }}
                     </p>


### PR DESCRIPTION
Added SVG clip path mask for developers avatars.
Because hexagon can not be squared, avatars must be 54x60 size.